### PR TITLE
Expose algorithm flags

### DIFF
--- a/src/fusion_ahrs_impl.rs
+++ b/src/fusion_ahrs_impl.rs
@@ -1,5 +1,5 @@
 use libm::{atan2f, cosf, fabsf, sinf};
-use crate::{fusion_degrees_to_radians, FusionAhrs, FusionAhrsSettings, FusionConvention, FusionQuaternion, FusionVector};
+use crate::{fusion_degrees_to_radians, FusionAhrs, FusionAhrsFlags, FusionAhrsSettings, FusionConvention, FusionQuaternion, FusionVector};
 use crate::FusionConvention::NWU;
 
 /**
@@ -310,6 +310,16 @@ impl FusionAhrs {
             FusionConvention::NED => {
                 self.acc + gravity
             }
+        }
+    }
+
+    pub fn flags(&self) -> FusionAhrsFlags {
+        FusionAhrsFlags {
+            initializing: self.initialising,
+            angular_rate_recovery: self.angular_rate_recovery,
+            acceleration_recovery: self.acceleration_recovery_trigger
+                > self.acceleration_recovery_timeout,
+            magnetic_recovery: self.magnetic_recovery_trigger > self.magnetic_recovery_timeout,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,13 @@ pub struct FusionAhrsSettings {
     pub recovery_trigger_period: i32,
 }
 
+pub struct FusionAhrsFlags {
+    pub initializing: bool,
+    pub angular_rate_recovery: bool,
+    pub acceleration_recovery: bool,
+    pub magnetic_recovery: bool,
+}
+
 #[derive(Copy, Clone)]
 pub struct Angle {
     pub roll: f32,


### PR DESCRIPTION
The C llibrary exposes a `FusionAhrsFlags` struct with a few commonly used flags that indicate the algorithm state. This PR adds the same struct to this port. Some fields are a bit redundant because they are also available on the `FusionAhrs` struct but this is also true for the C library so I thought it would make sense to mirror the behavior in this port.

My editor auto formatted the changed files using rustfmt. Let me know if that is a problem and I'll try to apply my changes without formatting the whole files.