### PR TITLE
Fix incorrect quaternion multiplication order in `set_heading`

### DIFF
--- a/src/fusion_ahrs_impl.rs
+++ b/src/fusion_ahrs_impl.rs
@@ -195,7 +195,7 @@ impl FusionAhrs {
             y: 0.0f32,
             z: -1.0f32 * sinf(half_yaw_minus_heading),
         };
-        self.quaternion = self.quaternion * rotation;
+        self.quaternion = rotation * self.quaternion;
     }
 
     pub fn reset(&mut self) {


### PR DESCRIPTION
Hey, thanks for the crate – it has been very helpful!

I noticed that the multiplication order in `set_heading` was incorrect.

As a result, the call to `set_heading(0.0f32)` during initialization did not properly reset the heading to zero and instead introduced an arbitrary offset due to the incorrect frame of rotation.

This PR fixes the issue.